### PR TITLE
feat(charts): add PNG export button

### DIFF
--- a/src/components/chart-export-button.tsx
+++ b/src/components/chart-export-button.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import type { Chart } from 'chart.js';
+import type { RefObject } from 'react';
+
+export function ChartExportButton({
+  chartRef,
+  title,
+}: {
+  chartRef: RefObject<Chart | null | undefined>;
+  title: string | null;
+}) {
+  function handleExport() {
+    const chart = chartRef.current;
+    if (!chart) return;
+
+    const base64 = chart.toBase64Image();
+    const link = document.createElement('a');
+    link.download = `${title ?? 'chart'}.png`;
+    link.href = base64;
+    link.click();
+  }
+
+  return (
+    <button
+      type="button"
+      aria-label="Export chart as PNG"
+      onClick={handleExport}
+      className="absolute top-2 right-2 z-10 flex size-7 items-center justify-center rounded-md bg-surface/80 text-ink-muted opacity-0 backdrop-blur-sm transition-opacity duration-200 ease-out hover:text-ink group-hover:opacity-100"
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="14"
+        height="14"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+        <polyline points="7 10 12 15 17 10" />
+        <line x1="12" y1="15" x2="12" y2="3" />
+      </svg>
+    </button>
+  );
+}

--- a/src/components/charts/area-chart.tsx
+++ b/src/components/charts/area-chart.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useRef } from 'react';
+import type { Chart } from 'chart.js';
 import type { AreaChartProps } from '@/lib/chart-schemas';
 import {
   ZOOM_OPTIONS,
@@ -9,29 +11,35 @@ import {
 } from '@/lib/chart-utils';
 import { useChartData } from '@/lib/use-chart-data';
 import { Line } from 'react-chartjs-2';
+import { ChartExportButton } from '@/components/chart-export-button';
 
 export function AreaChart({ props }: { props: AreaChartProps }) {
+  const chartRef = useRef<Chart<'line'> | null>(null);
   const resolved = useChartData(props);
   const stacked = props.stacked ?? false;
   return (
-    <Line
-      data={{
-        labels: resolved.labels,
-        datasets: mapDatasets(resolved.datasets, {
-          borderWidth: 2,
-          fill: true,
-          tension: 0.4,
-        }),
-      }}
-      options={{
-        responsive: true,
-        maintainAspectRatio: false,
-        plugins: { ...basePlugins(props), zoom: ZOOM_OPTIONS },
-        scales: {
-          x: { stacked },
-          y: { stacked, ...yAxisConfig(props.yFormat).y },
-        },
-      }}
-    />
+    <div className="group relative size-full">
+      <Line
+        ref={chartRef}
+        data={{
+          labels: resolved.labels,
+          datasets: mapDatasets(resolved.datasets, {
+            borderWidth: 2,
+            fill: true,
+            tension: 0.4,
+          }),
+        }}
+        options={{
+          responsive: true,
+          maintainAspectRatio: false,
+          plugins: { ...basePlugins(props), zoom: ZOOM_OPTIONS },
+          scales: {
+            x: { stacked },
+            y: { stacked, ...yAxisConfig(props.yFormat).y },
+          },
+        }}
+      />
+      <ChartExportButton chartRef={chartRef} title={props.title} />
+    </div>
   );
 }

--- a/src/components/charts/bar-chart.tsx
+++ b/src/components/charts/bar-chart.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useRef } from 'react';
+import type { Chart } from 'chart.js';
 import type { BarChartProps } from '@/lib/chart-schemas';
 import {
   ZOOM_OPTIONS,
@@ -9,8 +11,10 @@ import {
 } from '@/lib/chart-utils';
 import { useChartData } from '@/lib/use-chart-data';
 import { Bar } from 'react-chartjs-2';
+import { ChartExportButton } from '@/components/chart-export-button';
 
 export function BarChart({ props }: { props: BarChartProps }) {
+  const chartRef = useRef<Chart<'bar'> | null>(null);
   const resolved = useChartData(props);
   const stacked = props.stacked ?? false;
 
@@ -26,21 +30,25 @@ export function BarChart({ props }: { props: BarChartProps }) {
   );
 
   return (
-    <Bar
-      data={{
-        labels: resolved.labels,
-        datasets: datasets as Parameters<typeof Bar>[0]['data']['datasets'],
-      }}
-      options={{
-        responsive: true,
-        maintainAspectRatio: false,
-        indexAxis: props.indexAxis ?? 'x',
-        plugins: { ...basePlugins(props), zoom: ZOOM_OPTIONS },
-        scales: {
-          x: { stacked },
-          y: { stacked, ...yAxisConfig(props.yFormat).y },
-        },
-      }}
-    />
+    <div className="group relative size-full">
+      <Bar
+        ref={chartRef}
+        data={{
+          labels: resolved.labels,
+          datasets: datasets as Parameters<typeof Bar>[0]['data']['datasets'],
+        }}
+        options={{
+          responsive: true,
+          maintainAspectRatio: false,
+          indexAxis: props.indexAxis ?? 'x',
+          plugins: { ...basePlugins(props), zoom: ZOOM_OPTIONS },
+          scales: {
+            x: { stacked },
+            y: { stacked, ...yAxisConfig(props.yFormat).y },
+          },
+        }}
+      />
+      <ChartExportButton chartRef={chartRef} title={props.title} />
+    </div>
   );
 }

--- a/src/components/charts/doughnut-chart.tsx
+++ b/src/components/charts/doughnut-chart.tsx
@@ -1,23 +1,31 @@
 'use client';
 
+import { useRef } from 'react';
+import type { Chart } from 'chart.js';
 import type { DoughnutChartProps } from '@/lib/chart-schemas';
 import { basePlugins, mapDatasets } from '@/lib/chart-utils';
 import { useChartData } from '@/lib/use-chart-data';
 import { Doughnut } from 'react-chartjs-2';
+import { ChartExportButton } from '@/components/chart-export-button';
 
 export function DoughnutChart({ props }: { props: DoughnutChartProps }) {
+  const chartRef = useRef<Chart<'doughnut'> | null>(null);
   const resolved = useChartData(props);
   return (
-    <Doughnut
-      data={{
-        labels: resolved.labels,
-        datasets: mapDatasets(resolved.datasets, { borderWidth: 1 }),
-      }}
-      options={{
-        responsive: true,
-        maintainAspectRatio: false,
-        plugins: basePlugins(props),
-      }}
-    />
+    <div className="group relative size-full">
+      <Doughnut
+        ref={chartRef}
+        data={{
+          labels: resolved.labels,
+          datasets: mapDatasets(resolved.datasets, { borderWidth: 1 }),
+        }}
+        options={{
+          responsive: true,
+          maintainAspectRatio: false,
+          plugins: basePlugins(props),
+        }}
+      />
+      <ChartExportButton chartRef={chartRef} title={props.title} />
+    </div>
   );
 }

--- a/src/components/charts/line-chart.tsx
+++ b/src/components/charts/line-chart.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useRef } from 'react';
+import type { Chart } from 'chart.js';
 import type { LineChartProps } from '@/lib/chart-schemas';
 import {
   ZOOM_OPTIONS,
@@ -9,25 +11,31 @@ import {
 } from '@/lib/chart-utils';
 import { useChartData } from '@/lib/use-chart-data';
 import { Line } from 'react-chartjs-2';
+import { ChartExportButton } from '@/components/chart-export-button';
 
 export function LineChart({ props }: { props: LineChartProps }) {
+  const chartRef = useRef<Chart<'line'> | null>(null);
   const resolved = useChartData(props);
   return (
-    <Line
-      data={{
-        labels: resolved.labels,
-        datasets: mapDatasets(resolved.datasets, {
-          borderWidth: 2,
-          fill: false,
-          tension: 0.4,
-        }),
-      }}
-      options={{
-        responsive: true,
-        maintainAspectRatio: false,
-        plugins: { ...basePlugins(props), zoom: ZOOM_OPTIONS },
-        scales: yAxisConfig(props.yFormat),
-      }}
-    />
+    <div className="group relative size-full">
+      <Line
+        ref={chartRef}
+        data={{
+          labels: resolved.labels,
+          datasets: mapDatasets(resolved.datasets, {
+            borderWidth: 2,
+            fill: false,
+            tension: 0.4,
+          }),
+        }}
+        options={{
+          responsive: true,
+          maintainAspectRatio: false,
+          plugins: { ...basePlugins(props), zoom: ZOOM_OPTIONS },
+          scales: yAxisConfig(props.yFormat),
+        }}
+      />
+      <ChartExportButton chartRef={chartRef} title={props.title} />
+    </div>
   );
 }

--- a/src/components/charts/pie-chart.tsx
+++ b/src/components/charts/pie-chart.tsx
@@ -1,23 +1,31 @@
 'use client';
 
+import { useRef } from 'react';
+import type { Chart } from 'chart.js';
 import type { PieChartProps } from '@/lib/chart-schemas';
 import { basePlugins, mapDatasets } from '@/lib/chart-utils';
 import { useChartData } from '@/lib/use-chart-data';
 import { Pie } from 'react-chartjs-2';
+import { ChartExportButton } from '@/components/chart-export-button';
 
 export function PieChart({ props }: { props: PieChartProps }) {
+  const chartRef = useRef<Chart<'pie'> | null>(null);
   const resolved = useChartData(props);
   return (
-    <Pie
-      data={{
-        labels: resolved.labels,
-        datasets: mapDatasets(resolved.datasets, { borderWidth: 1 }),
-      }}
-      options={{
-        responsive: true,
-        maintainAspectRatio: false,
-        plugins: basePlugins(props),
-      }}
-    />
+    <div className="group relative size-full">
+      <Pie
+        ref={chartRef}
+        data={{
+          labels: resolved.labels,
+          datasets: mapDatasets(resolved.datasets, { borderWidth: 1 }),
+        }}
+        options={{
+          responsive: true,
+          maintainAspectRatio: false,
+          plugins: basePlugins(props),
+        }}
+      />
+      <ChartExportButton chartRef={chartRef} title={props.title} />
+    </div>
   );
 }

--- a/src/components/charts/radar-chart.tsx
+++ b/src/components/charts/radar-chart.tsx
@@ -1,26 +1,34 @@
 'use client';
 
+import { useRef } from 'react';
+import type { Chart } from 'chart.js';
 import type { RadarChartProps } from '@/lib/chart-schemas';
 import { basePlugins, mapDatasets } from '@/lib/chart-utils';
 import { useChartData } from '@/lib/use-chart-data';
 import { Radar } from 'react-chartjs-2';
+import { ChartExportButton } from '@/components/chart-export-button';
 
 export function RadarChart({ props }: { props: RadarChartProps }) {
+  const chartRef = useRef<Chart<'radar'> | null>(null);
   const resolved = useChartData(props);
   return (
-    <Radar
-      data={{
-        labels: resolved.labels,
-        datasets: mapDatasets(resolved.datasets, {
-          borderWidth: 2,
-          fill: true,
-        }),
-      }}
-      options={{
-        responsive: true,
-        maintainAspectRatio: false,
-        plugins: basePlugins(props),
-      }}
-    />
+    <div className="group relative size-full">
+      <Radar
+        ref={chartRef}
+        data={{
+          labels: resolved.labels,
+          datasets: mapDatasets(resolved.datasets, {
+            borderWidth: 2,
+            fill: true,
+          }),
+        }}
+        options={{
+          responsive: true,
+          maintainAspectRatio: false,
+          plugins: basePlugins(props),
+        }}
+      />
+      <ChartExportButton chartRef={chartRef} title={props.title} />
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- Adds a download icon button overlay on all 6 chart components for PNG export
- Shared `ChartExportButton` component uses `chart.toBase64Image()` to capture canvas
- Triggers browser download with chart-type filename

## Test plan
- [ ] Verify download button appears on all chart types (line, bar, area, pie, doughnut, radar)
- [ ] Click export — verify PNG file downloads with correct content
- [ ] Button styling consistent across chart types

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)