### PR TITLE
feat(data): add real-time data source connections

### DIFF
--- a/src/app/dashboard/[id]/page.tsx
+++ b/src/app/dashboard/[id]/page.tsx
@@ -1,11 +1,13 @@
 'use client';
 
 import { ChatPanel } from '@/components/chat-panel';
+import { DataSourcePanel } from '@/components/data-source-panel';
 import { Sidebar } from '@/components/sidebar';
 import { DEFAULT_DASHBOARD_ID } from '@/lib/default-dashboard';
 import { removeElementFromSpec } from '@/lib/spec-utils';
 import { useChat } from '@/lib/use-chat';
 import { useDashboards } from '@/lib/use-dashboards';
+import { useDataSources } from '@/lib/use-data-sources';
 import type { Spec } from '@json-render/core';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/navigation';
@@ -80,6 +82,9 @@ export default function DashboardPage({
   const resetLayoutRef = useRef<(() => void) | null>(null);
   const [sidebarOpen, setSidebarOpen] = usePersistedState('sidebar-open', true);
   const [chatOpen, setChatOpen] = usePersistedState('chat-open', true);
+  const [dataSourcePanelOpen, setDataSourcePanelOpen] = useState(false);
+  const { sources, configs, addSource, removeSource, refreshSource } =
+    useDataSources();
 
   const initialMessages = useMemo(
     () => activeDashboard?.messages ?? [],
@@ -251,6 +256,38 @@ export default function DashboardPage({
 
           <div className="flex items-center gap-2">
             <button
+              onClick={() => setDataSourcePanelOpen(true)}
+              className="size-8 flex items-center justify-center text-ink-muted hover:text-accent transition-colors duration-200 ease-out"
+              aria-label="Manage data sources"
+            >
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 16 16"
+                fill="none"
+                aria-hidden="true"
+              >
+                <ellipse
+                  cx="8"
+                  cy="4"
+                  rx="5.5"
+                  ry="2.5"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                />
+                <path
+                  d="M2.5 4v4c0 1.38 2.46 2.5 5.5 2.5s5.5-1.12 5.5-2.5V4"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                />
+                <path
+                  d="M2.5 8v4c0 1.38 2.46 2.5 5.5 2.5s5.5-1.12 5.5-2.5V8"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                />
+              </svg>
+            </button>
+            <button
               onClick={() => setChatOpen(o => !o)}
               className="size-8 flex items-center justify-center text-ink-muted hover:text-accent transition-colors duration-200 ease-out"
               aria-label="Toggle chat"
@@ -283,6 +320,7 @@ export default function DashboardPage({
             <DashboardRenderer
               spec={displaySpec}
               loading={isStreaming}
+              sources={sources}
               onResetLayout={reset => {
                 resetLayoutRef.current = reset;
               }}
@@ -308,6 +346,16 @@ export default function DashboardPage({
           showExamples={showExamples}
         />
       </div>
+
+      {dataSourcePanelOpen && (
+        <DataSourcePanel
+          configs={configs}
+          onAdd={addSource}
+          onRemove={removeSource}
+          onRefresh={refreshSource}
+          onClose={() => setDataSourcePanelOpen(false)}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/dashboard-renderer.tsx
+++ b/src/components/dashboard-renderer.tsx
@@ -3,7 +3,6 @@
 import { GridDashboard } from '@/components/grid-dashboard';
 import '@/lib/chartjs-setup';
 import { DataProvider } from '@/lib/data-context';
-import projectsData from '@/lib/projects.json';
 import { registry } from '@/lib/registry';
 import type { Spec } from '@json-render/core';
 import {
@@ -14,9 +13,12 @@ import {
 } from '@json-render/react';
 import type { ReactNode } from 'react';
 
+type Row = Record<string, unknown>;
+
 interface DashboardRendererProps {
   spec: Spec | null;
   loading: boolean;
+  sources: Record<string, Row[]>;
   onResetLayout?: (reset: () => void) => void;
   onRemoveItem?: (key: string) => void;
 }
@@ -30,13 +32,14 @@ const fallback: ComponentRenderer = ({ element }) => (
 export function DashboardRenderer({
   spec,
   loading,
+  sources,
   onResetLayout,
   onRemoveItem,
 }: DashboardRendererProps): ReactNode {
   if (!spec) return null;
 
   return (
-    <DataProvider projects={projectsData.projects as Record<string, unknown>[]}>
+    <DataProvider sources={sources}>
       <StateProvider initialState={{}}>
         <VisibilityProvider>
           <ActionProvider handlers={{}}>

--- a/src/components/data-source-panel.tsx
+++ b/src/components/data-source-panel.tsx
@@ -1,0 +1,318 @@
+'use client';
+
+import type { DataSourceConfig } from '@/lib/data-sources';
+import { fetchDataSource } from '@/lib/data-fetcher';
+import { useCallback, useState } from 'react';
+
+interface DataSourcePanelProps {
+  configs: DataSourceConfig[];
+  onAdd: (config: DataSourceConfig) => void;
+  onRemove: (id: string) => void;
+  onRefresh: (id: string) => void;
+  onClose: () => void;
+}
+
+export function DataSourcePanel({
+  configs,
+  onAdd,
+  onRemove,
+  onRefresh,
+  onClose,
+}: DataSourcePanelProps) {
+  const [showForm, setShowForm] = useState(false);
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div
+        className="absolute inset-0 bg-black/40"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+      <div className="relative w-full max-w-lg rounded-lg border border-border/60 bg-[rgb(var(--background))] shadow-lg">
+        <div className="flex items-center justify-between border-b border-border/60 px-4 py-3">
+          <h2 className="text-sm font-semibold text-balance">Data Sources</h2>
+          <button
+            onClick={onClose}
+            className="size-7 flex items-center justify-center rounded text-ink-muted hover:text-ink transition-colors"
+            aria-label="Close data sources panel"
+          >
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 14 14"
+              fill="none"
+              aria-hidden="true"
+            >
+              <path
+                d="M1 1L13 13M13 1L1 13"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+              />
+            </svg>
+          </button>
+        </div>
+
+        <div className="max-h-[60dvh] overflow-y-auto p-4">
+          <ul className="space-y-2">
+            {configs.map(config => (
+              <li
+                key={config.id}
+                className="flex items-center justify-between rounded border border-border/60 px-3 py-2"
+              >
+                <div className="min-w-0">
+                  <p className="truncate text-sm font-medium">{config.name}</p>
+                  <p className="truncate text-xs text-ink-muted">
+                    {config.type === 'static'
+                      ? 'Built-in'
+                      : config.url ?? 'REST'}
+                    {config.refreshInterval
+                      ? ` / ${Math.round(config.refreshInterval / 1000)}s`
+                      : ''}
+                  </p>
+                </div>
+                <div className="flex items-center gap-1 shrink-0 ml-2">
+                  {config.type === 'rest' && (
+                    <button
+                      onClick={() => onRefresh(config.id)}
+                      className="rounded px-2 py-1 text-xs text-ink-muted hover:text-ink transition-colors"
+                      aria-label={`Refresh ${config.name}`}
+                    >
+                      Refresh
+                    </button>
+                  )}
+                  {config.type !== 'static' && (
+                    <button
+                      onClick={() => onRemove(config.id)}
+                      className="rounded px-2 py-1 text-xs text-red-400 hover:text-red-300 transition-colors"
+                      aria-label={`Remove ${config.name}`}
+                    >
+                      Remove
+                    </button>
+                  )}
+                </div>
+              </li>
+            ))}
+          </ul>
+
+          {showForm ? (
+            <AddSourceForm
+              onAdd={config => {
+                onAdd(config);
+                setShowForm(false);
+              }}
+              onCancel={() => setShowForm(false)}
+            />
+          ) : (
+            <button
+              onClick={() => setShowForm(true)}
+              className="mt-3 w-full rounded border border-dashed border-border/60 px-3 py-2 text-sm text-ink-muted hover:text-ink hover:border-border transition-colors"
+            >
+              + Add REST data source
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface AddSourceFormProps {
+  onAdd: (config: DataSourceConfig) => void;
+  onCancel: () => void;
+}
+
+function AddSourceForm({ onAdd, onCancel }: AddSourceFormProps) {
+  const [name, setName] = useState('');
+  const [url, setUrl] = useState('');
+  const [transform, setTransform] = useState('');
+  const [refreshInterval, setRefreshInterval] = useState('');
+  const [headerKey, setHeaderKey] = useState('');
+  const [headerValue, setHeaderValue] = useState('');
+  const [headers, setHeaders] = useState<Record<string, string>>({});
+  const [testResult, setTestResult] = useState<string | null>(null);
+  const [isTesting, setIsTesting] = useState(false);
+
+  const buildConfig = useCallback((): DataSourceConfig => {
+    const id = name
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-|-$/g, '');
+    return {
+      id: id || `source-${Date.now()}`,
+      name,
+      type: 'rest',
+      url,
+      headers: Object.keys(headers).length > 0 ? headers : undefined,
+      refreshInterval: refreshInterval
+        ? parseInt(refreshInterval, 10) * 1000
+        : undefined,
+      transform: transform || undefined,
+    };
+  }, [name, url, transform, refreshInterval, headers]);
+
+  const handleAddHeader = useCallback(() => {
+    if (!headerKey.trim()) return;
+    setHeaders(prev => ({ ...prev, [headerKey.trim()]: headerValue }));
+    setHeaderKey('');
+    setHeaderValue('');
+  }, [headerKey, headerValue]);
+
+  const handleRemoveHeader = useCallback((key: string) => {
+    setHeaders(prev => {
+      const next = { ...prev };
+      delete next[key];
+      return next;
+    });
+  }, []);
+
+  const handleTest = useCallback(async () => {
+    setIsTesting(true);
+    setTestResult(null);
+    try {
+      const config = buildConfig();
+      const rows = await fetchDataSource(config);
+      setTestResult(`Connected: ${rows.length} rows`);
+    } catch (err) {
+      setTestResult(
+        `Error: ${err instanceof Error ? err.message : 'Unknown error'}`
+      );
+    } finally {
+      setIsTesting(false);
+    }
+  }, [buildConfig]);
+
+  const handleSubmit = useCallback(() => {
+    if (!name.trim() || !url.trim()) return;
+    onAdd(buildConfig());
+  }, [name, url, buildConfig, onAdd]);
+
+  const inputClass =
+    'w-full rounded border border-border/60 bg-transparent px-2.5 py-1.5 text-sm text-ink placeholder:text-ink-dim focus:border-accent focus:outline-none';
+
+  return (
+    <div className="mt-3 space-y-3 rounded border border-border/60 p-3">
+      <div>
+        <label className="mb-1 block text-xs text-ink-muted">Name</label>
+        <input
+          type="text"
+          value={name}
+          onChange={e => setName(e.target.value)}
+          placeholder="My API data"
+          className={inputClass}
+        />
+      </div>
+
+      <div>
+        <label className="mb-1 block text-xs text-ink-muted">URL</label>
+        <input
+          type="url"
+          value={url}
+          onChange={e => setUrl(e.target.value)}
+          placeholder="https://api.example.com/data"
+          className={inputClass}
+        />
+      </div>
+
+      <div>
+        <label className="mb-1 block text-xs text-ink-muted">
+          Transform path (optional, e.g. &quot;data.items&quot;)
+        </label>
+        <input
+          type="text"
+          value={transform}
+          onChange={e => setTransform(e.target.value)}
+          placeholder="data.items"
+          className={inputClass}
+        />
+      </div>
+
+      <div>
+        <label className="mb-1 block text-xs text-ink-muted">
+          Refresh interval in seconds (optional)
+        </label>
+        <input
+          type="number"
+          min="0"
+          value={refreshInterval}
+          onChange={e => setRefreshInterval(e.target.value)}
+          placeholder="30"
+          className={inputClass}
+        />
+      </div>
+
+      <div>
+        <label className="mb-1 block text-xs text-ink-muted">
+          Headers (optional)
+        </label>
+        {Object.entries(headers).map(([key, val]) => (
+          <div key={key} className="mb-1 flex items-center gap-1 text-xs">
+            <span className="truncate text-ink-muted">
+              {key}: {val}
+            </span>
+            <button
+              onClick={() => handleRemoveHeader(key)}
+              className="shrink-0 text-red-400 hover:text-red-300"
+              aria-label={`Remove header ${key}`}
+            >
+              x
+            </button>
+          </div>
+        ))}
+        <div className="flex gap-1">
+          <input
+            type="text"
+            value={headerKey}
+            onChange={e => setHeaderKey(e.target.value)}
+            placeholder="Key"
+            className={`${inputClass} flex-1`}
+          />
+          <input
+            type="text"
+            value={headerValue}
+            onChange={e => setHeaderValue(e.target.value)}
+            placeholder="Value"
+            className={`${inputClass} flex-1`}
+          />
+          <button
+            onClick={handleAddHeader}
+            className="shrink-0 rounded border border-border/60 px-2 py-1 text-xs text-ink-muted hover:text-ink transition-colors"
+          >
+            Add
+          </button>
+        </div>
+      </div>
+
+      {testResult && (
+        <p
+          className={`text-xs ${testResult.startsWith('Error') ? 'text-red-400' : 'text-green-400'}`}
+        >
+          {testResult}
+        </p>
+      )}
+
+      <div className="flex items-center justify-end gap-2">
+        <button
+          onClick={handleTest}
+          disabled={!url.trim() || isTesting}
+          className="rounded border border-border/60 px-3 py-1.5 text-xs text-ink-muted hover:text-ink disabled:opacity-40 transition-colors"
+        >
+          {isTesting ? 'Testing...' : 'Test connection'}
+        </button>
+        <button
+          onClick={onCancel}
+          className="rounded px-3 py-1.5 text-xs text-ink-muted hover:text-ink transition-colors"
+        >
+          Cancel
+        </button>
+        <button
+          onClick={handleSubmit}
+          disabled={!name.trim() || !url.trim()}
+          className="rounded bg-accent px-3 py-1.5 text-xs text-white disabled:opacity-40 transition-colors"
+        >
+          Add source
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/catalog.ts
+++ b/src/lib/catalog.ts
@@ -73,7 +73,7 @@ export const catalog = defineCatalog(schema, {
     BarChart: {
       props: barChartSchema,
       description:
-        'Bar chart. Use dataQuery for a single series or dataQueries (array) with datasetLabels for multi-series overlays (e.g. capacity + count by year). Each query in dataQueries produces one dataset with a distinct color. All queries should share the same groupBy for aligned labels. Set top-level backgroundColor/borderColor to override default palette colors.',
+        'Bar chart. Use dataQuery for a single series or dataQueries (array) with datasetLabels for multi-series overlays (e.g. capacity + count by year). Each query in dataQueries produces one dataset with a distinct color. All queries should share the same groupBy for aligned labels. Set top-level backgroundColor/borderColor to override default palette colors. The dataQuery source can be any registered data source id (default: "projects").',
       example: {
         title: 'Projects by Country (Top 10)',
         dataQuery: {

--- a/src/lib/chart-schemas.ts
+++ b/src/lib/chart-schemas.ts
@@ -57,7 +57,7 @@ export type RadarChartProps = z.infer<typeof radarChartSchema>;
 export const dataTableSchema = z.object({
   title: z.string().nullable(),
   columns: z.array(z.string()),
-  source: z.literal('projects'),
+  source: z.string(),
   filter: z
     .record(z.string(), z.union([z.string(), z.array(z.string())]))
     .nullable(),

--- a/src/lib/data-context.tsx
+++ b/src/lib/data-context.tsx
@@ -4,26 +4,23 @@ import { createContext, useContext, type ReactNode } from 'react';
 
 type Row = Record<string, unknown>;
 
-interface DataSources {
-  projects: Row[];
-}
+type DataSources = Record<string, Row[]>;
 
-const DataContext = createContext<DataSources>({ projects: [] });
+const DataContext = createContext<DataSources>({});
 
 export function DataProvider({
-  projects,
+  sources,
   children,
 }: {
-  projects: Row[];
+  sources: DataSources;
   children: ReactNode;
 }) {
   return (
-    <DataContext.Provider value={{ projects }}>{children}</DataContext.Provider>
+    <DataContext.Provider value={sources}>{children}</DataContext.Provider>
   );
 }
 
 export function useDataSource(source: string): Row[] {
   const ctx = useContext(DataContext);
-  if (source === 'projects') return ctx.projects;
-  return [];
+  return ctx[source] ?? [];
 }

--- a/src/lib/data-fetcher.ts
+++ b/src/lib/data-fetcher.ts
@@ -1,0 +1,72 @@
+import type { DataSourceConfig } from './data-sources';
+import projectsData from './projects.json';
+
+type Row = Record<string, unknown>;
+
+interface CacheEntry {
+  data: Row[];
+  timestamp: number;
+}
+
+const cache = new Map<string, CacheEntry>();
+
+function applyTransform(data: unknown, transform: string): Row[] {
+  const parts = transform.split('.');
+  let current: unknown = data;
+  for (const part of parts) {
+    if (current == null || typeof current !== 'object') return [];
+    current = (current as Record<string, unknown>)[part];
+  }
+  if (!Array.isArray(current)) return [];
+  return current as Row[];
+}
+
+export async function fetchDataSource(
+  config: DataSourceConfig
+): Promise<Row[]> {
+  if (config.type === 'static' && config.id === 'projects') {
+    return projectsData.projects as Row[];
+  }
+
+  if (config.type !== 'rest' || !config.url) {
+    return [];
+  }
+
+  const cached = cache.get(config.id);
+  const interval = config.refreshInterval ?? 0;
+  if (cached && interval > 0 && Date.now() - cached.timestamp < interval) {
+    return cached.data;
+  }
+
+  const response = await fetch(config.url, {
+    headers: config.headers ?? {},
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch ${config.name}: ${response.status} ${response.statusText}`
+    );
+  }
+
+  const json: unknown = await response.json();
+
+  let rows: Row[];
+  if (config.transform) {
+    rows = applyTransform(json, config.transform);
+  } else if (Array.isArray(json)) {
+    rows = json as Row[];
+  } else {
+    rows = [];
+  }
+
+  cache.set(config.id, { data: rows, timestamp: Date.now() });
+  return rows;
+}
+
+export function clearCache(sourceId?: string): void {
+  if (sourceId) {
+    cache.delete(sourceId);
+  } else {
+    cache.clear();
+  }
+}

--- a/src/lib/data-query.ts
+++ b/src/lib/data-query.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 // ─── Schema ──────────────────────────────────────────────────
 
 export const dataQuerySchema = z.object({
-  source: z.literal('projects'),
+  source: z.string(),
   filter: z
     .record(z.string(), z.union([z.string(), z.array(z.string())]))
     .nullable(),

--- a/src/lib/data-sources.ts
+++ b/src/lib/data-sources.ts
@@ -1,0 +1,54 @@
+const STORAGE_KEY = 'data-source-configs';
+
+export interface DataSourceConfig {
+  id: string;
+  name: string;
+  type: 'static' | 'rest';
+  url?: string;
+  headers?: Record<string, string>;
+  refreshInterval?: number;
+  transform?: string;
+}
+
+export const BUILTIN_PROJECTS_SOURCE: DataSourceConfig = {
+  id: 'projects',
+  name: 'Projects',
+  type: 'static',
+};
+
+export function getDataSources(): DataSourceConfig[] {
+  if (typeof window === 'undefined') return [BUILTIN_PROJECTS_SOURCE];
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    const custom: DataSourceConfig[] = raw ? JSON.parse(raw) : [];
+    return [
+      BUILTIN_PROJECTS_SOURCE,
+      ...custom.filter(c => c.id !== 'projects'),
+    ];
+  } catch {
+    return [BUILTIN_PROJECTS_SOURCE];
+  }
+}
+
+export function addDataSource(config: DataSourceConfig): DataSourceConfig[] {
+  if (config.id === 'projects') {
+    throw new Error('Cannot override the built-in projects source');
+  }
+  const existing = getDataSources().filter(
+    c => c.id !== config.id && c.id !== 'projects'
+  );
+  const updated = [...existing, config];
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+  return [BUILTIN_PROJECTS_SOURCE, ...updated];
+}
+
+export function removeDataSource(id: string): DataSourceConfig[] {
+  if (id === 'projects') {
+    throw new Error('Cannot remove the built-in projects source');
+  }
+  const updated = getDataSources().filter(
+    c => c.id !== id && c.id !== 'projects'
+  );
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+  return [BUILTIN_PROJECTS_SOURCE, ...updated];
+}

--- a/src/lib/use-chart-data.ts
+++ b/src/lib/use-chart-data.ts
@@ -32,7 +32,11 @@ interface ChartProps {
 }
 
 export function useChartData(props: ChartProps): ResolvedChartData {
-  const projects = useDataSource('projects');
+  const source =
+    props.dataQuery?.source ??
+    props.dataQueries?.[0]?.source ??
+    'projects';
+  const data = useDataSource(source);
 
   return useMemo(() => {
     const applyOverrides = (
@@ -49,7 +53,7 @@ export function useChartData(props: ChartProps): ResolvedChartData {
     // Prefer dataQueries (multi-series) if provided
     if (props.dataQueries && props.dataQueries.length > 0) {
       const resolved = resolveMultiQuery(
-        projects,
+        data,
         props.dataQueries,
         props.datasetLabels ?? undefined
       );
@@ -59,7 +63,7 @@ export function useChartData(props: ChartProps): ResolvedChartData {
     // Single dataQuery
     if (props.dataQuery) {
       const resolved = resolveQuery(
-        projects,
+        data,
         props.dataQuery,
         props.datasetLabel ?? undefined
       );
@@ -81,7 +85,7 @@ export function useChartData(props: ChartProps): ResolvedChartData {
       ),
     };
   }, [
-    projects,
+    data,
     props.dataQuery,
     props.dataQueries,
     props.datasetLabel,

--- a/src/lib/use-data-sources.ts
+++ b/src/lib/use-data-sources.ts
@@ -1,0 +1,125 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { clearCache, fetchDataSource } from './data-fetcher';
+import {
+  addDataSource,
+  getDataSources,
+  removeDataSource,
+  type DataSourceConfig,
+} from './data-sources';
+
+type Row = Record<string, unknown>;
+
+interface UseDataSourcesResult {
+  sources: Record<string, Row[]>;
+  configs: DataSourceConfig[];
+  addSource: (config: DataSourceConfig) => void;
+  removeSource: (id: string) => void;
+  refreshSource: (id: string) => void;
+  isLoading: boolean;
+}
+
+export function useDataSources(): UseDataSourcesResult {
+  const [configs, setConfigs] = useState<DataSourceConfig[]>([]);
+  const [sources, setSources] = useState<Record<string, Row[]>>({});
+  const [isLoading, setIsLoading] = useState(true);
+  const intervalsRef = useRef<Map<string, ReturnType<typeof setInterval>>>(
+    new Map()
+  );
+
+  const fetchSource = useCallback(
+    async (config: DataSourceConfig) => {
+      try {
+        const data = await fetchDataSource(config);
+        setSources(prev => ({ ...prev, [config.id]: data }));
+      } catch (err) {
+        console.error(`Failed to fetch data source "${config.name}":`, err);
+      }
+    },
+    []
+  );
+
+  const setupInterval = useCallback(
+    (config: DataSourceConfig) => {
+      const existing = intervalsRef.current.get(config.id);
+      if (existing) clearInterval(existing);
+
+      if (
+        config.type === 'rest' &&
+        config.refreshInterval &&
+        config.refreshInterval > 0
+      ) {
+        const id = setInterval(() => {
+          clearCache(config.id);
+          fetchSource(config);
+        }, config.refreshInterval);
+        intervalsRef.current.set(config.id, id);
+      }
+    },
+    [fetchSource]
+  );
+
+  // Load configs and fetch all sources on mount
+  useEffect(() => {
+    const allConfigs = getDataSources();
+    setConfigs(allConfigs);
+
+    setIsLoading(true);
+    Promise.all(allConfigs.map(c => fetchSource(c))).finally(() =>
+      setIsLoading(false)
+    );
+
+    for (const config of allConfigs) {
+      setupInterval(config);
+    }
+
+    return () => {
+      for (const id of intervalsRef.current.values()) {
+        clearInterval(id);
+      }
+      intervalsRef.current.clear();
+    };
+    // Run only on mount
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const addSource = useCallback(
+    (config: DataSourceConfig) => {
+      const updated = addDataSource(config);
+      setConfigs(updated);
+      fetchSource(config);
+      setupInterval(config);
+    },
+    [fetchSource, setupInterval]
+  );
+
+  const removeSourceCb = useCallback((id: string) => {
+    const updated = removeDataSource(id);
+    setConfigs(updated);
+    setSources(prev => {
+      const next = { ...prev };
+      delete next[id];
+      return next;
+    });
+    const intervalId = intervalsRef.current.get(id);
+    if (intervalId) {
+      clearInterval(intervalId);
+      intervalsRef.current.delete(id);
+    }
+    clearCache(id);
+  }, []);
+
+  const refreshSource = useCallback(
+    (id: string) => {
+      const config = configs.find(c => c.id === id);
+      if (config) {
+        clearCache(id);
+        fetchSource(config);
+      }
+    },
+    [configs, fetchSource]
+  );
+
+  return { sources, configs, addSource, removeSource: removeSourceCb, refreshSource, isLoading };
+}


### PR DESCRIPTION
## Summary
- Adds data source configuration layer with localStorage persistence and built-in projects source
- Adds REST data fetcher with response caching, configurable refresh intervals, and jq-like transform paths
- Adds `useDataSources()` hook managing fetch, auto-refresh, and CRUD for data source configs
- Adds data source management panel UI with add/remove/test-connection/refresh controls
- Updates DataProvider to accept generic `Record<string, Row[]>` sources
- Changes `source` field in dataQuerySchema and dataTableSchema from `z.literal('projects')` to `z.string()`

## Test plan
- [ ] Verify existing projects data still renders correctly
- [ ] Open data source panel via database icon in header
- [ ] Add a REST data source and test connection
- [ ] Verify refresh interval and remove/refresh controls work
- [ ] Verify data sources persist across page reloads via localStorage

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)